### PR TITLE
Update Adafruit_ZeroTimer.cpp

### DIFF
--- a/Adafruit_ZeroTimer.cpp
+++ b/Adafruit_ZeroTimer.cpp
@@ -53,7 +53,12 @@ bool Adafruit_ZeroTimer::tc_init()
 
 #if defined(__SAMD51__)
 /* Array of GLCK ID for different TC instances */
-  uint32_t inst_gclk_id[] = { TC3_GCLK_ID, TC4_GCLK_ID, TC5_GCLK_ID };
+  #if defined(TC4_GCLK_ID)
+  uint32_t inst_gclk_id[] = { TC3_GCLK_ID , TC4_GCLK_ID, TC5_GCLK_ID  };
+  #else
+  uint32_t inst_gclk_id[] = { TC3_GCLK_ID /* , TC4_GCLK_ID, TC5_GCLK_ID */ };
+  #endif
+
  #else
   /* Array of GLCK ID for different TC instances */
   uint32_t inst_gclk_id[] = {GCLK_CLKCTRL_ID(GCM_TCC2_TC3), GCLK_CLKCTRL_ID(GCM_TC4_TC5), GCLK_CLKCTRL_ID(GCM_TC4_TC5)};
@@ -258,6 +263,7 @@ boolean Adafruit_ZeroTimer::PWMout(boolean pwmout, uint8_t channum, uint8_t pin)
     uint32_t pinmux = 0xFFFF;
 
 #if defined(__SAMD51__)
+
     if (_timernum == 3){
       if (channum == 0){
         if (pin == 10){
@@ -276,7 +282,7 @@ boolean Adafruit_ZeroTimer::PWMout(boolean pwmout, uint8_t channum, uint8_t pin)
         }
       }
     }
-
+#if defined(PIN_PB08E_TC4_WO0)
     if (_timernum == 4){
       if (channum == 0){
         if (pin == A4){
@@ -323,6 +329,7 @@ boolean Adafruit_ZeroTimer::PWMout(boolean pwmout, uint8_t channum, uint8_t pin)
         }
       }
     }
+    #endif
 #else
     if (_timernum == 3)
     {
@@ -524,8 +531,11 @@ void Adafruit_ZeroTimer::setCallback(boolean enable, tc_callback cb_type, void (
       _enable_callback_mask |= (1UL << cb_type) << (instance*TC_CALLBACK_BITS);
       __cb[cb_type + (instance*TC_CALLBACK_BITS)] = callback_func;
     }
-
+    #if defined(TC4_IRQn)
     IRQn_Type _irqs[] = { TC3_IRQn, TC4_IRQn, TC5_IRQn };
+    #else
+    IRQn_Type _irqs[] = { TC3_IRQn /* , TC4_IRQn, TC5_IRQn */ };
+    #endif
     NVIC_ClearPendingIRQ(_irqs[instance]);
     NVIC_EnableIRQ(_irqs[instance]);
 
@@ -651,6 +661,7 @@ void Adafruit_ZeroTimer::timerHandler(uint8_t timerNum){
       __tc_cb_handler(mask, 0);
       TC3->COUNT8.INTFLAG.reg = 0b00111011; //clear
       break;
+    #if defined(TC4)
     case 4:
       mask = TC4->COUNT8.INTFLAG.reg;
       __tc_cb_handler(mask, TC_CALLBACK_BITS);
@@ -661,6 +672,7 @@ void Adafruit_ZeroTimer::timerHandler(uint8_t timerNum){
       __tc_cb_handler(mask, TC_CALLBACK_BITS*2);
       TC5->COUNT8.INTFLAG.reg = 0b00111011; //clear
       break;
+    #endif
   }
 }
 


### PR DESCRIPTION
allow compile on samd51 (qfn48 variants) when missing TC4, TC5 on MCU.
Known Boards: ItsyBitsy M4 , doppler

